### PR TITLE
Update documentation to work with non module format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ On the other hand, it currently doesn’t provide it for `.property` value testi
 
 ```js
 const chai = require('chai')
-const chaiJestDiff = require('chai-jest-diff')
+const chaiJestDiff = require('chai-jest-diff').default
 
 chai.use(chaiJestDiff())
 ```


### PR DESCRIPTION
Hey,

I just tried to use your library and it seems like the default export doesn't work unless you add `.default`

Thanks